### PR TITLE
chore(security): upgrade react-router, bump Node to 24, update @types/node

### DIFF
--- a/.github/workflows/RELEASE_WORKFLOW.md
+++ b/.github/workflows/RELEASE_WORKFLOW.md
@@ -23,7 +23,7 @@ This repository uses GitHub Actions to publish workspace packages when you push 
 
 **Required:**
 
-- Node.js 20+ and npm installed
+- Node.js 24+ and npm installed
 - Push access to the repository
 - npm publish permissions for `@platonic-dice` scope
 

--- a/.github/workflows/auto-patch-bump.yml
+++ b/.github/workflows/auto-patch-bump.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
       - uses: actions/setup-node@v4
-        with: { node-version: "20" }
+        with: { node-version: "24" }
       - name: Detect changed packages (PR files)
         id: changes
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
@@ -64,7 +64,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/label-version-bump.yml
+++ b/.github/workflows/label-version-bump.yml
@@ -14,7 +14,10 @@ env:
 
 jobs:
   bump-on-label:
+    if: contains(env.ALLOWED_LABELS, github.event.label.name)
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check label is a recognized semver label
         id: check_label

--- a/.github/workflows/pnpm-updater.yml
+++ b/.github/workflows/pnpm-updater.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
       - uses: actions/setup-node@v4
-        with: { node-version: "20" }
+        with: { node-version: "24" }
       - name: Get latest pnpm
         id: pnpm
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "workspaces": [
     "packages/*"
   ],
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "test": "CI=true pnpm -r test",
     "build": "pnpm -r build"
@@ -30,6 +33,6 @@
     "tsd": "^0.31.2",
     "ts-jest": "^29.4.5",
     "@types/jest": "^30.0.0",
-    "@types/node": "^22.13.8"
+    "@types/node": "^24.0.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,9 @@
   "name": "@platonic-dice/core",
   "version": "2.2.2",
   "packageManager": "pnpm@8.15.9",
+  "engines": {
+    "node": ">=24"
+  },
   "description": "Core JavaScript logic for simulating TTRPG dice rolls.",
   "main": "dist/index.js",
   "types": "dist-types.d.ts",

--- a/packages/dice/package.json
+++ b/packages/dice/package.json
@@ -2,6 +2,9 @@
   "name": "@platonic-dice/dice",
   "version": "2.2.1",
   "packageManager": "pnpm@8.15.9",
+  "engines": {
+    "node": ">=24"
+  },
   "description": "Persistent dice objects with roll history and TypeScript support.",
   "type": "module",
   "main": "dist/index.js",
@@ -46,6 +49,6 @@
     "tsc-alias": "^1.8.16",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^4.0.9",
-    "@types/node": "^22.13.8"
+    "@types/node": "^24.0.0"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,6 +3,9 @@
   "version": "0.2.2",
   "private": true,
   "packageManager": "pnpm@8.15.9",
+  "engines": {
+    "node": ">=24"
+  },
   "description": "React showcase application for @platonic-dice packages (PREVIEW)",
   "type": "module",
   "keywords": [
@@ -37,7 +40,7 @@
     "@platonic-dice/dice": "^2.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^7.9.6"
+    "react-router-dom": "^7.13.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,14 +12,14 @@ importers:
         specifier: ^30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: ^22.13.8
-        version: 22.13.8
+        specifier: ^24.0.0
+        version: 24.10.13
       '@vitest/coverage-v8':
         specifier: ^4.0.9
         version: 4.0.9(vitest@4.0.9)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.13.8)
+        version: 29.7.0(@types/node@24.10.13)
       ts-jest:
         specifier: ^29.4.5
         version: 29.4.5(@babel/core@7.28.5)(jest@29.7.0)(typescript@5.9.3)
@@ -34,7 +34,7 @@ importers:
         version: 5.1.4(typescript@5.9.3)
       vitest:
         specifier: ^4.0.9
-        version: 4.0.9(@types/node@22.13.8)(jsdom@23.2.0)
+        version: 4.0.9(@types/node@24.10.13)(jsdom@23.2.0)
 
   packages/core: {}
 
@@ -45,8 +45,8 @@ importers:
         version: link:../core
     devDependencies:
       '@types/node':
-        specifier: ^22.13.8
-        version: 22.13.8
+        specifier: ^24.0.0
+        version: 24.10.13
       tsc-alias:
         specifier: ^1.8.16
         version: 1.8.16
@@ -55,7 +55,7 @@ importers:
         version: 5.1.4(typescript@5.9.3)
       vitest:
         specifier: ^4.0.9
-        version: 4.0.9(@types/node@22.13.8)(jsdom@23.2.0)
+        version: 4.0.9(@types/node@24.10.13)(jsdom@23.2.0)
 
   packages/ui:
     dependencies:
@@ -72,8 +72,8 @@ importers:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
       react-router-dom:
-        specifier: ^7.9.6
-        version: 7.9.6(react-dom@18.3.1)(react@18.3.1)
+        specifier: ^7.13.0
+        version: 7.13.0(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1
@@ -128,10 +128,10 @@ importers:
         version: 8.47.0(eslint@9.39.1)(typescript@5.9.3)
       vite:
         specifier: ^6.4.1
-        version: 6.4.1(@types/node@22.13.8)
+        version: 6.4.1(@types/node@24.10.13)
       vitest:
         specifier: ^4.0.9
-        version: 4.0.9(@types/node@22.13.8)(jsdom@23.2.0)
+        version: 4.0.9(@types/node@24.10.13)(jsdom@23.2.0)
 
 packages:
 
@@ -902,7 +902,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -923,14 +923,14 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.13.8)
+      jest-config: 29.7.0(@types/node@24.10.13)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -963,7 +963,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       jest-mock: 29.7.0
     dev: true
 
@@ -997,7 +997,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -1024,7 +1024,7 @@ packages:
     resolution: {integrity: sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     dependencies:
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       jest-regex-util: 30.0.1
     dev: true
 
@@ -1043,7 +1043,7 @@ packages:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -1138,7 +1138,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       '@types/yargs': 17.0.33
       chalk: 4.1.2
     dev: true
@@ -1151,7 +1151,7 @@ packages:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       '@types/yargs': 17.0.33
       chalk: 4.1.2
     dev: true
@@ -1564,7 +1564,7 @@ packages:
   /@types/graceful-fs@4.1.9:
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
     dependencies:
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
     dev: true
 
   /@types/istanbul-lib-coverage@2.0.6:
@@ -1598,10 +1598,10 @@ packages:
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
     dev: true
 
-  /@types/node@22.13.8:
-    resolution: {integrity: sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ==}
+  /@types/node@24.10.13:
+    resolution: {integrity: sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==}
     dependencies:
-      undici-types: 6.20.0
+      undici-types: 7.16.0
     dev: true
 
   /@types/normalize-package-data@2.4.4:
@@ -1795,7 +1795,7 @@ packages:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@22.13.8)
+      vite: 6.4.1(@types/node@24.10.13)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1820,7 +1820,7 @@ packages:
       magicast: 0.5.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.9(@types/node@22.13.8)(jsdom@23.2.0)
+      vitest: 4.0.9(@types/node@24.10.13)(jsdom@23.2.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1850,7 +1850,7 @@ packages:
       '@vitest/spy': 4.0.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      vite: 6.4.1(@types/node@22.13.8)
+      vite: 6.4.1(@types/node@24.10.13)
     dev: true
 
   /@vitest/pretty-format@4.0.9:
@@ -2273,7 +2273,7 @@ packages:
     engines: {node: '>=18'}
     dev: false
 
-  /create-jest@29.7.0(@types/node@22.13.8):
+  /create-jest@29.7.0(@types/node@24.10.13):
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -2282,7 +2282,7 @@ packages:
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.13.8)
+      jest-config: 29.7.0(@types/node@24.10.13)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -3268,7 +3268,7 @@ packages:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -3289,7 +3289,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli@29.7.0(@types/node@22.13.8):
+  /jest-cli@29.7.0(@types/node@24.10.13):
     resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -3303,10 +3303,10 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.13.8)
+      create-jest: 29.7.0(@types/node@24.10.13)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.13.8)
+      jest-config: 29.7.0(@types/node@24.10.13)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -3317,7 +3317,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config@29.7.0(@types/node@22.13.8):
+  /jest-config@29.7.0(@types/node@24.10.13):
     resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -3332,7 +3332,7 @@ packages:
       '@babel/core': 7.28.5
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       babel-jest: 29.7.0(@babel/core@7.28.5)
       chalk: 4.1.2
       ci-info: 3.9.0
@@ -3402,7 +3402,7 @@ packages:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       jest-mock: 29.7.0
       jest-util: 29.7.0
     dev: true
@@ -3418,7 +3418,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -3494,7 +3494,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       jest-util: 29.7.0
     dev: true
 
@@ -3503,7 +3503,7 @@ packages:
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       jest-util: 30.2.0
     dev: true
 
@@ -3563,7 +3563,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -3594,7 +3594,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.2
@@ -3646,7 +3646,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -3658,7 +3658,7 @@ packages:
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       chalk: 4.1.2
       ci-info: 4.3.1
       graceful-fs: 4.2.11
@@ -3683,7 +3683,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -3695,13 +3695,13 @@ packages:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
 
-  /jest@29.7.0(@types/node@22.13.8):
+  /jest@29.7.0(@types/node@24.10.13):
     resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -3714,7 +3714,7 @@ packages:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.13.8)
+      jest-cli: 29.7.0(@types/node@24.10.13)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -4347,8 +4347,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /react-router-dom@7.9.6(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-2MkC2XSXq6HjGcihnx1s0DBWQETI4mlis4Ux7YTLvP67xnGxCvq+BcCQSO81qQHVUTM1V53tl4iVVaY5sReCOA==}
+  /react-router-dom@7.13.0(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -4356,11 +4356,11 @@ packages:
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 7.9.6(react-dom@18.3.1)(react@18.3.1)
+      react-router: 7.13.0(react-dom@18.3.1)(react@18.3.1)
     dev: false
 
-  /react-router@7.9.6(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-Y1tUp8clYRXpfPITyuifmSoE2vncSME18uVLgaqyxh9H35JWpIfzHo+9y3Fzh5odk/jxPW29IgLgzcdwxGqyNA==}
+  /react-router@7.13.0(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -4819,7 +4819,7 @@ packages:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 29.7.0(@types/node@22.13.8)
+      jest: 29.7.0(@types/node@24.10.13)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -4938,8 +4938,8 @@ packages:
     dev: true
     optional: true
 
-  /undici-types@6.20.0:
-    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+  /undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
     dev: true
 
   /universalify@0.2.0:
@@ -5003,7 +5003,7 @@ packages:
       - typescript
     dev: true
 
-  /vite@6.4.1(@types/node@22.13.8):
+  /vite@6.4.1(@types/node@24.10.13):
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -5043,7 +5043,7 @@ packages:
       yaml:
         optional: true
     dependencies:
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
@@ -5054,7 +5054,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@4.0.9(@types/node@22.13.8)(jsdom@23.2.0):
+  /vitest@4.0.9(@types/node@24.10.13)(jsdom@23.2.0):
     resolution: {integrity: sha512-E0Ja2AX4th+CG33yAFRC+d1wFx2pzU5r6HtG6LiPSE04flaE0qB6YyjSw9ZcpJAtVPfsvZGtJlKWZpuW7EHRxg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
@@ -5088,7 +5088,7 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@types/node': 22.13.8
+      '@types/node': 24.10.13
       '@vitest/expect': 4.0.9
       '@vitest/mocker': 4.0.9(vite@6.4.1)
       '@vitest/pretty-format': 4.0.9
@@ -5108,7 +5108,7 @@ packages:
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 6.4.1(@types/node@22.13.8)
+      vite: 6.4.1(@types/node@24.10.13)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
This PR:

- upgrades  to  to address multiple GHSA advisories
- sets  to  across the monorepo and updates GitHub Actions to Node 24
- updates  to 
- updates  and runs workspace tests

CI will validate the change. Please review and merge to address the reported security issues.