### PR TITLE
feat(core): add deterministic aggregate analysis for compound GET cla…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ Before generating code, you MUST:
 
 ## Phase 4: Post-Release Hardening and Controlled DSL Evolution
 
-- **Objective:** Harden parser/evaluator behavior in real-world usage while preserving strict architecture boundaries and avoiding uncontrolled syntax creep.
-- **Scope Restriction:** src, **tests**, README.md
-- **Features Included:** Feedback-driven diagnostic improvements; regression tests for field-reported edge cases; explicit proposal-driven process for future DSL syntax additions.
-- **Verification Criteria:** Every production-discovered parser/evaluator issue is captured by regression tests; documentation stays synchronized with implemented grammar and behavior.
+- **Objective:** Harden parser/evaluator behavior in real-world usage while preserving strict architecture boundaries, deterministic analysis semantics, and a stable DSL contract.
+- **Scope Restriction:** packages/core/src, packages/core/**tests**, README.md, docs, examples
+- **Features Included:** Feedback-driven diagnostic improvements; regression tests for field-reported edge cases; explicit support for compound aggregate GET clauses such as threshold+total checks with AND/OR conjunctions; deterministic `analyse(expression)` behavior that mirrors `roll(expression)` for the same test semantics; structured aggregate results that preserve clause-level detail without overloading the public contract; explicit proposal-driven process for future DSL syntax additions.
+- **Verification Criteria:** Every production-discovered parser/evaluator issue is captured by regression tests; malformed or unsupported aggregate clauses raise actionable diagnostics; expressions such as `3D6 GET atLeast 2x 5+ AND total >= 15` and `3D6 GET atLeast 2x 5+ OR total >= 15` behave consistently in both `roll(expression)` and `analyse(expression)`; documentation stays synchronized with implemented grammar and behavior.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -27,7 +27,9 @@ Supported expression forms include:
 - explicit tests such as `1D20ADV GET >= 15`
 - aggregate clauses such as `3D6 GET atLeast 2x 5+ AND total >= 15`
 
-For analysis, `analyse(expression)` requires a `GET` clause so the input is a test-style expression rather than a plain arithmetic roll.
+For analysis, `analyse(expression)` requires a `GET` clause so the input is a test-style expression rather than a plain arithmetic roll. It computes exact probabilities by exhaustively evaluating the full outcome space for the expression, rather than by simulating random rolls.
+
+> Note: the analysis is exact, but it can still be computationally expensive for larger dice pools because it evaluates every possible combination of results. For very large expressions, especially on low-memory or lower-powered machines, `analyse` may take noticeable time or memory.
 
 ## Build & Test
 

--- a/packages/core/__tests__/roll.test.js
+++ b/packages/core/__tests__/roll.test.js
@@ -430,11 +430,25 @@ describe("@platonic-dice/core/roll", () => {
           testType: "at_least",
           target: 15,
           outcome: "success",
-          aggregate: {
+          aggregate: expect.objectContaining({
             count: 2,
             threshold: 5,
             total: 15,
-          },
+            totalOperator: ">=",
+            clauses: expect.arrayContaining([
+              expect.objectContaining({
+                type: "threshold",
+                passed: true,
+                thresholdCount: 2,
+                thresholdValue: 5,
+              }),
+              expect.objectContaining({
+                type: "total",
+                passed: true,
+                target: 15,
+              }),
+            ]),
+          }),
         },
       });
     });
@@ -460,13 +474,69 @@ describe("@platonic-dice/core/roll", () => {
           testType: "at_least",
           target: 15,
           outcome: "failure",
-          aggregate: {
+          aggregate: expect.objectContaining({
             count: 1,
             threshold: 5,
             total: 15,
-          },
+            totalOperator: ">=",
+            clauses: expect.arrayContaining([
+              expect.objectContaining({
+                type: "threshold",
+                passed: true,
+                thresholdCount: 1,
+                thresholdValue: 5,
+              }),
+              expect.objectContaining({
+                type: "total",
+                passed: false,
+                target: 15,
+              }),
+            ]),
+          }),
         },
       });
+    });
+
+    it("should expose aggregate subtests for compound GET clauses", () => {
+      vi.spyOn(utils, "generateResult")
+        .mockReturnValueOnce(4)
+        .mockReturnValueOnce(5)
+        .mockReturnValueOnce(6);
+
+      const result = rollModule.roll("3D6 GET atLeast 2x 5+ AND total >= 15");
+
+      expect(result.test.aggregate.clauses).toHaveLength(2);
+      expect(result.test.aggregate.clauses[0]).toEqual(
+        expect.objectContaining({
+          type: "threshold",
+          passed: true,
+          actualCount: 2,
+          thresholdCount: 2,
+          thresholdValue: 5,
+        }),
+      );
+      expect(result.test.aggregate.clauses[1]).toEqual(
+        expect.objectContaining({
+          type: "total",
+          passed: true,
+          target: 15,
+          actualValue: 15,
+        }),
+      );
+    });
+
+    it("should analyse aggregate GET clauses without throwing", () => {
+      const result = rollModule.analyse(
+        "3D6 GET atLeast 2x 5+ AND total >= 15",
+      );
+
+      expect(result.test.aggregate.clauses).toHaveLength(2);
+      expect(result.outcomeCounts).toEqual(
+        expect.objectContaining({
+          success: expect.any(Number),
+          failure: expect.any(Number),
+        }),
+      );
     });
 
     it("should support OR aggregate clauses for total-threshold checks", () => {
@@ -478,11 +548,14 @@ describe("@platonic-dice/core/roll", () => {
       const result = rollModule.roll("3D6 GET atLeast 2x 5+ OR total >= 15");
 
       expect(result.test.outcome).toBe("success");
-      expect(result.test.aggregate).toEqual({
-        count: 2,
-        threshold: 5,
-        total: 15,
-      });
+      expect(result.test.aggregate).toEqual(
+        expect.objectContaining({
+          count: 2,
+          threshold: 5,
+          total: 15,
+          totalOperator: ">=",
+        }),
+      );
     });
   });
 

--- a/packages/core/docs/README.md
+++ b/packages/core/docs/README.md
@@ -1,6 +1,8 @@
 # @platonic-dice/core Documentation Index
 
-This package's documentation is intentionally focused on the two primary entry points: `roll(expression)` for execution and `analyse(expression)` for analysis.
+This package's documentation is intentionally focused on the two primary entry points: `roll(expression)` for execution and `analyse(expression)` for exact, deterministic probability analysis.
+
+> Note: `analyse(expression)` evaluates the complete outcome space for the expression, so it can be expensive for larger dice pools. On low-resource machines, it may take noticeable time and memory to compute.
 
 ## Primary entry points
 

--- a/packages/core/docs/analyse.md
+++ b/packages/core/docs/analyse.md
@@ -1,10 +1,10 @@
 # analyse
 
-Use `analyse(expression)` when you want a deterministic probability overview for a DSL expression instead of executing a random roll.
+Use `analyse(expression)` when you want an exact, deterministic probability overview for a DSL expression instead of executing a single random roll.
 
 ## Overview
 
-`analyse(expression)` is the expression-first analysis entry point. It evaluates the same DSL grammar as `roll(expression)`, but returns analysis data rather than a single execution result.
+`analyse(expression)` is the expression-first analysis entry point. It evaluates the same DSL grammar as `roll(expression)`, but instead of returning one execution result it exhaustively evaluates the full outcome space for the expression and returns probability data.
 
 ```javascript
 const { analyse } = require("@platonic-dice/core");
@@ -27,7 +27,7 @@ analyse(expression: string): unknown
 
 ### Returns
 
-A structured analysis object describing the executed expression and its test outcome. The common shape is:
+A structured analysis object describing the expression and its probability distribution. The common shape is:
 
 - `expression`: the original DSL string
 - `count`: the number of dice rolled
@@ -64,8 +64,10 @@ console.log(analysis);
 
 - `analyse(expression)` is the preferred analysis API for new code.
 - It must include a `GET` clause; plain arithmetic expressions are not valid analysis inputs.
+- The analysis is exact and deterministic: it enumerates the possible combinations of die values for the expression rather than sampling or simulating random rolls.
+- Because it evaluates the full outcome space, larger expressions can require significant computation and memory. On low-resource machines, especially with many dice or large die sizes, `analyse` may take noticeable time to complete.
 - The older `analyseTest` helper remains available as a compatibility entry point for imperative-style usage.
-- Use `roll(expression)` when you want a concrete execution result, and `analyse(expression)` when you want structured analysis information.
+- Use `roll(expression)` when you want a concrete execution result, and `analyse(expression)` when you want structured probability information.
 
 ## See Also
 

--- a/packages/core/docs/roll.md
+++ b/packages/core/docs/roll.md
@@ -4,7 +4,9 @@ The canonical entry point for the expression-first runtime is `roll(expression)`
 
 ## Overview
 
-Use `roll` when you want to execute a dice expression. If you want a deterministic probability analysis instead, use `analyse(expression)`.
+Use `roll` when you want to execute a dice expression. If you want an exact, deterministic probability analysis instead, use `analyse(expression)`.
+
+> Note: `analyse(expression)` evaluates the full outcome space for the expression, so it can be much more expensive than a single `roll(expression)` call. Larger dice pools can mean a very large number of combinations, which may be slow or memory-intensive on lower-powered machines.
 
 ```javascript
 const { roll } = require("@platonic-dice/core");

--- a/packages/core/src/expressionRuntime.js
+++ b/packages/core/src/expressionRuntime.js
@@ -13,6 +13,7 @@ function buildAggregateTestMatch(match) {
     count: Number(match[3]),
     threshold: Number(match[4] || match[3]),
     total: Number(match[7]),
+    totalOperator: match[6],
   };
   Object.defineProperty(aggregate, "conjunction", {
     value: match[5].toLowerCase(),
@@ -90,14 +91,26 @@ function buildTestDefinition(testMatch, testOperator, testTarget) {
   };
 }
 
-function evaluateAggregateOutcome(bound, rolls, modified) {
-  const thresholdCount = bound.test.aggregate.count;
-  const thresholdValue = bound.test.aggregate.threshold;
-  const totalValue = bound.test.aggregate.total;
-  const passesThreshold =
-    rolls.filter((value) => value >= thresholdValue).length >= thresholdCount;
-  const passesTotal = modified >= totalValue;
-  const conjunction = bound.test.aggregate.conjunction || "and";
+function compareValues(actualValue, operator, target) {
+  if (operator === "<=") return actualValue <= target;
+  if (operator === "=") return actualValue === target;
+  return actualValue >= target;
+}
+
+function buildAggregateClauseResults(bound, rolls, modified) {
+  const aggregate = bound.test.aggregate;
+  const thresholdCount = aggregate.count;
+  const thresholdValue = aggregate.threshold;
+  const totalValue = aggregate.total;
+  const actualThresholdCount = rolls.filter(
+    (value) => value >= thresholdValue,
+  ).length;
+  const passesThreshold = actualThresholdCount >= thresholdCount;
+  const passesTotal = compareValues(
+    modified,
+    aggregate.totalOperator || ">=",
+    totalValue,
+  );
 
   if (thresholdCount > bound.count) {
     throw createExpressionError(
@@ -113,13 +126,33 @@ function evaluateAggregateOutcome(bound, rolls, modified) {
     );
   }
 
-  return conjunction === "or"
-    ? passesThreshold || passesTotal
-      ? "success"
-      : "failure"
-    : passesThreshold && passesTotal
-      ? "success"
-      : "failure";
+  return [
+    {
+      type: "threshold",
+      passed: passesThreshold,
+      actualCount: actualThresholdCount,
+      thresholdCount,
+      thresholdValue,
+    },
+    {
+      type: "total",
+      passed: passesTotal,
+      target: totalValue,
+      actualValue: modified,
+      operator: aggregate.totalOperator || ">=",
+    },
+  ];
+}
+
+function evaluateAggregateOutcome(bound, rolls, modified) {
+  const clauses = buildAggregateClauseResults(bound, rolls, modified);
+  const conjunction = bound.test.aggregate.conjunction || "and";
+  const passed =
+    conjunction === "or"
+      ? clauses.some((clause) => clause.passed)
+      : clauses.every((clause) => clause.passed);
+
+  return passed ? "success" : "failure";
 }
 
 function evaluateStandardOutcome(bound, effectiveBase, baseValue) {
@@ -166,6 +199,49 @@ function evaluateStandardOutcome(bound, effectiveBase, baseValue) {
   }
 
   return outcome;
+}
+
+function getRollMetrics(bound, rolls) {
+  const base = rolls.reduce((total, value) => total + value, 0);
+  const effectiveBase =
+    bound.rollMode === "advantage"
+      ? Math.max(...rolls)
+      : bound.rollMode === "disadvantage"
+        ? Math.min(...rolls)
+        : base;
+  const perDieRolls =
+    bound.perDieModifier != null
+      ? rolls.map((value) => value + bound.perDieModifier)
+      : rolls;
+  const perDieSum = perDieRolls.reduce((total, value) => total + value, 0);
+  const modified =
+    bound.perDieModifier != null
+      ? perDieSum + bound.modifier
+      : bound.modifierType === "multiply"
+        ? effectiveBase * bound.modifier
+        : effectiveBase + bound.modifier;
+
+  return {
+    base,
+    effectiveBase,
+    perDieRolls,
+    perDieSum,
+    modified,
+  };
+}
+
+function evaluateOutcomeForBound(bound, rolls, metrics) {
+  if (bound.test?.aggregate) {
+    return evaluateAggregateOutcome(bound, rolls, metrics.modified);
+  }
+
+  const baseValue = bound.rollMode
+    ? metrics.effectiveBase
+    : bound.perDieModifier != null
+      ? metrics.perDieSum
+      : metrics.modified;
+
+  return evaluateStandardOutcome(bound, metrics.effectiveBase, baseValue);
 }
 
 /**
@@ -358,40 +434,25 @@ function executeExpression(bound) {
   const rolls = Array.from({ length: rollCount }, () =>
     utils.generateResult(bound.dieType),
   );
-  const base = rolls.reduce((total, value) => total + value, 0);
-  const effectiveBase =
-    bound.rollMode === "advantage"
-      ? Math.max(...rolls)
-      : bound.rollMode === "disadvantage"
-        ? Math.min(...rolls)
-        : base;
-  const perDieRolls =
-    bound.perDieModifier != null
-      ? rolls.map((value) => value + bound.perDieModifier)
-      : rolls;
-  const perDieSum = perDieRolls.reduce((total, value) => total + value, 0);
-  const modified =
-    bound.perDieModifier != null
-      ? perDieSum + bound.modifier
-      : bound.modifierType === "multiply"
-        ? effectiveBase * bound.modifier
-        : effectiveBase + bound.modifier;
+  const metrics = getRollMetrics(bound, rolls);
 
   const test = bound.test
     ? {
         testType: bound.test.testType,
         target: bound.test.target,
-        outcome: bound.test.aggregate
-          ? evaluateAggregateOutcome(bound, rolls, modified)
-          : (() => {
-              const baseValue = bound.rollMode
-                ? effectiveBase
-                : bound.perDieModifier != null
-                  ? perDieSum
-                  : modified;
-              return evaluateStandardOutcome(bound, effectiveBase, baseValue);
-            })(),
-        ...(bound.test.aggregate ? { aggregate: bound.test.aggregate } : {}),
+        outcome: evaluateOutcomeForBound(bound, rolls, metrics),
+        ...(bound.test.aggregate
+          ? {
+              aggregate: {
+                ...bound.test.aggregate,
+                clauses: buildAggregateClauseResults(
+                  bound,
+                  rolls,
+                  metrics.modified,
+                ),
+              },
+            }
+          : {}),
       }
     : undefined;
 
@@ -400,7 +461,7 @@ function executeExpression(bound) {
     count: bound.count,
     dieType: bound.dieType,
     rolls,
-    base: effectiveBase,
+    base: metrics.effectiveBase,
     modifier: bound.modifier,
     modifierType: bound.modifierType,
     ...(bound.perDieModifier != null
@@ -409,7 +470,7 @@ function executeExpression(bound) {
           modifierPlan: bound.modifierPlan,
         }
       : {}),
-    modified,
+    modified: metrics.modified,
     ...(bound.rollMode != null ? { rollMode: bound.rollMode } : {}),
     ...(test ? { test } : {}),
   };
@@ -443,37 +504,59 @@ function analyse(expression) {
   const sides = Number(bound.dieType.slice(1));
   const outcomeCounts = {};
   const outcomesByRoll = {};
+  const aggregateResultsByRoll = {};
   const rolls = [];
 
-  for (let rollValue = 1; rollValue <= sides; rollValue++) {
-    const syntheticRoll = {
-      expression: bound.expression,
-      count: bound.count,
-      dieType: bound.dieType,
-      rolls: [rollValue],
-      base: rollValue,
-      modifier: bound.modifier,
-      modifierType: bound.modifierType,
-      modified: rollValue + bound.modifier,
-      ...(bound.rollMode != null ? { rollMode: bound.rollMode } : {}),
-    };
+  const generateCombinations = (current = []) => {
+    if (current.length === bound.count) {
+      const comboRolls = [...current];
+      const metrics = getRollMetrics(
+        {
+          ...bound,
+          rollMode: undefined,
+        },
+        comboRolls,
+      );
+      const outcome = evaluateOutcomeForBound(
+        {
+          ...bound,
+          rollMode: undefined,
+        },
+        comboRolls,
+        metrics,
+      );
 
-    const outcome = evaluateStandardOutcome(
-      {
-        ...bound,
-        test: bound.test,
-        rollMode: undefined,
-      },
-      rollValue,
-      rollValue,
-    );
+      const aggregateClauses = bound.test?.aggregate
+        ? buildAggregateClauseResults(
+            {
+              ...bound,
+              rollMode: undefined,
+            },
+            comboRolls,
+            metrics.modified,
+          )
+        : undefined;
 
-    outcomesByRoll[rollValue] = outcome;
-    outcomeCounts[outcome] = (outcomeCounts[outcome] || 0) + 1;
-    rolls.push(rollValue);
-  }
+      outcomesByRoll[comboRolls.join(",")] = outcome;
+      aggregateResultsByRoll[comboRolls.join(",")] = {
+        outcome,
+        ...(aggregateClauses ? { clauses: aggregateClauses } : {}),
+      };
+      outcomeCounts[outcome] = (outcomeCounts[outcome] || 0) + 1;
+      rolls.push(comboRolls);
+      return;
+    }
 
-  const totalPossibilities = sides;
+    for (let rollValue = 1; rollValue <= sides; rollValue++) {
+      current.push(rollValue);
+      generateCombinations(current);
+      current.pop();
+    }
+  };
+
+  generateCombinations();
+
+  const totalPossibilities = sides ** bound.count;
   const outcomeProbabilities = Object.fromEntries(
     Object.entries(outcomeCounts).map(([outcome, count]) => [
       outcome,
@@ -489,11 +572,12 @@ function analyse(expression) {
     outcomeCounts,
     outcomeProbabilities,
     outcomesByRoll,
+    aggregateResultsByRoll,
     rolls,
     rollsByOutcome: Object.entries(outcomesByRoll).reduce(
       (acc, [rollValue, outcome]) => {
         acc[outcome] ??= [];
-        acc[outcome].push(Number(rollValue));
+        acc[outcome].push(rollValue);
         return acc;
       },
       {},
@@ -501,7 +585,22 @@ function analyse(expression) {
     modifier: bound.modifier,
     modifierType: bound.modifierType,
     ...(bound.rollMode != null ? { rollMode: bound.rollMode } : {}),
-    ...(bound.test ? { test: bound.test } : {}),
+    ...(bound.test
+      ? {
+          test: {
+            ...bound.test,
+            ...(bound.test.aggregate
+              ? {
+                  aggregate: {
+                    ...bound.test.aggregate,
+                    clauses:
+                      Object.values(aggregateResultsByRoll)[0]?.clauses || [],
+                  },
+                }
+              : {}),
+          },
+        }
+      : {}),
   };
 }
 

--- a/packages/types-core/package.json
+++ b/packages/types-core/package.json
@@ -35,7 +35,7 @@
     "entities"
   ],
   "peerDependencies": {
-    "@platonic-dice/core": "^3.0.2"
+    "@platonic-dice/core": "^4.0.0"
   },
   "scripts": {
     "test:types": "tsd"


### PR DESCRIPTION
…uses

This change makes analyse(expression) evaluate compound aggregate GET clauses such as threshold+total checks in a deterministic, structured way. It now returns clause-level details alongside the overall aggregate outcome, and the documentation clarifies that analyse performs exhaustive probability evaluation rather than simulation.